### PR TITLE
[Feat] 예약 현황 조회 기능 구현 및 단위 테스트 작성

### DIFF
--- a/nowait-api/build.gradle
+++ b/nowait-api/build.gradle
@@ -17,6 +17,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // H2
+    runtimeOnly 'com.h2database:h2'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/nowait-api/build.gradle
+++ b/nowait-api/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // H2
     runtimeOnly 'com.h2database:h2'

--- a/nowait-api/src/main/java/com/nowait/booking/api/BookingApi.java
+++ b/nowait-api/src/main/java/com/nowait/booking/api/BookingApi.java
@@ -1,6 +1,8 @@
 package com.nowait.booking.api;
 
-import com.nowait.booking.dto.TimeSlotDto;
+import static java.util.Objects.isNull;
+
+import com.nowait.booking.application.BookingService;
 import com.nowait.booking.dto.request.BookingReq;
 import com.nowait.booking.dto.response.BookingRes;
 import com.nowait.booking.dto.response.DailyBookingStatusRes;
@@ -11,7 +13,6 @@ import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,6 +29,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class BookingApi {
 
+    private final BookingService bookingService;
+
     /**
      * 가게 예약 현황 조회 API
      *
@@ -40,12 +43,8 @@ public class BookingApi {
         @RequestParam Long placeId,
         @RequestParam(required = false) LocalDate date
     ) {
-        // TODO: 예약 현황 조회 비즈니스 로직 호출
-
-        return ApiResult.ok(
-            new DailyBookingStatusRes(placeId, date,
-                List.of(new TimeSlotDto(LocalTime.of(18, 0), true)))
-        );
+        date = isNull(date) ? LocalDate.now() : date;
+        return ApiResult.ok(bookingService.getDailyBookingStatus(placeId, date));
     }
 
     /**

--- a/nowait-api/src/main/java/com/nowait/booking/application/BookingService.java
+++ b/nowait-api/src/main/java/com/nowait/booking/application/BookingService.java
@@ -1,0 +1,36 @@
+package com.nowait.booking.application;
+
+import com.nowait.booking.domain.model.BookingSlot;
+import com.nowait.booking.domain.repository.BookingSlotRepository;
+import com.nowait.booking.dto.TimeSlotDto;
+import com.nowait.booking.dto.response.DailyBookingStatusRes;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookingService {
+
+    private final BookingSlotRepository bookingSlotRepository;
+
+    public DailyBookingStatusRes getDailyBookingStatus(Long placeId, LocalDate date) {
+        List<BookingSlot> bookingSlots = bookingSlotRepository.findAllByPlaceIdAndDate(
+            placeId, date);
+
+        List<TimeSlotDto> timeSlots = bookingSlots.stream()
+            .collect(Collectors.groupingBy(BookingSlot::getTime))
+            .entrySet().stream()
+            .map(entry -> new TimeSlotDto(entry.getKey(), isAvailable(entry.getValue())))
+            .toList();
+
+        return new DailyBookingStatusRes(placeId, date, timeSlots);
+    }
+
+    private boolean isAvailable(List<BookingSlot> slots) {
+        // 모든 슬롯이 예약된 경우에만 false 반환
+        return slots.stream().anyMatch(slot -> !slot.isBooked());
+    }
+}

--- a/nowait-api/src/main/java/com/nowait/booking/domain/model/Booking.java
+++ b/nowait-api/src/main/java/com/nowait/booking/domain/model/Booking.java
@@ -1,0 +1,38 @@
+package com.nowait.booking.domain.model;
+
+import com.nowait.common.domain.model.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "booking")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Booking extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "booking_slot_id", nullable = false)
+    private Long bookingSlotId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "status", nullable = false, columnDefinition = "varchar(20)")
+    private BookingStatus status;
+}

--- a/nowait-api/src/main/java/com/nowait/booking/domain/model/BookingSlot.java
+++ b/nowait-api/src/main/java/com/nowait/booking/domain/model/BookingSlot.java
@@ -1,0 +1,52 @@
+package com.nowait.booking.domain.model;
+
+import com.nowait.common.domain.model.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "booking_slot")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BookingSlot extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "place_id", nullable = false)
+    private Long placeId;
+
+    @Column(name = "table_id", nullable = false)
+    private Long tableId;
+
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    @Column(name = "time", nullable = false)
+    private LocalTime time;
+
+    @Column(name = "is_booked")
+    private boolean isBooked;
+
+    @Column(name = "deposit_required")
+    private boolean depositRequired;
+
+    @Column(name = "confirm_required")
+    private boolean confirmRequired;
+
+    @Column(name = "deposit_policy_id")
+    private Long deposit_policy_id;
+}

--- a/nowait-api/src/main/java/com/nowait/booking/domain/model/BookingStatus.java
+++ b/nowait-api/src/main/java/com/nowait/booking/domain/model/BookingStatus.java
@@ -1,0 +1,13 @@
+package com.nowait.booking.domain.model;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum BookingStatus {
+    CONFIRMED("확정됨"),
+    PENDING_CONFIRM("확정 대기 중"),
+    PENDING_PAYMENT("결재 대기 중"),
+    CANCELLED("취소됨");
+
+    private final String description;
+}

--- a/nowait-api/src/main/java/com/nowait/booking/domain/repository/BookingRepository.java
+++ b/nowait-api/src/main/java/com/nowait/booking/domain/repository/BookingRepository.java
@@ -1,0 +1,8 @@
+package com.nowait.booking.domain.repository;
+
+import com.nowait.booking.domain.model.Booking;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookingRepository extends JpaRepository<Booking, Long> {
+
+}

--- a/nowait-api/src/main/java/com/nowait/booking/domain/repository/BookingSlotRepository.java
+++ b/nowait-api/src/main/java/com/nowait/booking/domain/repository/BookingSlotRepository.java
@@ -1,0 +1,11 @@
+package com.nowait.booking.domain.repository;
+
+import com.nowait.booking.domain.model.BookingSlot;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookingSlotRepository extends JpaRepository<BookingSlot, Long> {
+
+    List<BookingSlot> findAllByPlaceIdAndDate(Long placeId, LocalDate date);
+}

--- a/nowait-api/src/main/java/com/nowait/common/config/JpaConfig.java
+++ b/nowait-api/src/main/java/com/nowait/common/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.nowait.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/nowait-api/src/main/java/com/nowait/common/domain/model/BaseTimeEntity.java
+++ b/nowait-api/src/main/java/com/nowait/common/domain/model/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.nowait.common.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/nowait-api/src/main/resources/application-local.yml
+++ b/nowait-api/src/main/resources/application-local.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:nowait;MODE=MySQL;
+    username: sa
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true

--- a/nowait-api/src/test/java/com/nowait/booking/api/BookingApiIntegrationTest.java
+++ b/nowait-api/src/test/java/com/nowait/booking/api/BookingApiIntegrationTest.java
@@ -2,6 +2,8 @@ package com.nowait.booking.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.nowait.booking.domain.model.BookingSlot;
+import com.nowait.booking.domain.repository.BookingSlotRepository;
 import com.nowait.booking.dto.request.BookingReq;
 import com.nowait.booking.dto.response.BookingRes;
 import com.nowait.booking.dto.response.DailyBookingStatusRes;
@@ -12,6 +14,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -30,8 +33,12 @@ import org.springframework.web.util.UriComponentsBuilder;
 class BookingApiIntegrationTest {
 
     @Autowired
-    private TestRestTemplate template;
-    private String authorization;
+    TestRestTemplate template;
+
+    @Autowired
+    BookingSlotRepository bookingSlotRepository;
+
+    String authorization;
 
     @BeforeEach
     void setUp() {
@@ -39,42 +46,54 @@ class BookingApiIntegrationTest {
         authorization = "Bearer " + accessToken;
     }
 
-    @DisplayName("사용자는 특정 날짜에 가게의 예약 가능 시간을 확인할 수 있다")
-    @Test
-    void getDailyBookingStatus() {
-        // given
-        long placeId = 1L;
-        LocalDate date = LocalDate.of(2024, 12, 25);
+    @Nested
+    @DisplayName("예약 현황 조회 테스트")
+    class DailyBookingStatusTest {
 
-        String url = UriComponentsBuilder.fromPath("/api/bookings")
-            .queryParam("placeId", placeId)
-            .queryParam("date", date)
-            .toUriString();
+        @DisplayName("사용자는 특정 날짜에 가게의 예약 가능 시간을 확인할 수 있다")
+        @Test
+        void getDailyBookingStatus() {
+            // given
+            long placeId = 1L;
+            LocalDate date = LocalDate.of(2024, 12, 25);
 
-        // when
-        ResponseEntity<ApiResult<DailyBookingStatusRes>> result = template.exchange(
-            url,
-            HttpMethod.GET,
-            null,
-            new ParameterizedTypeReference<>() {
-            }
-        );
+            BookingSlot bookingSlot = createBookingSlot(placeId, date, LocalTime.of(18, 0));
+            bookingSlotRepository.save(bookingSlot);
 
-        // then
-        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+            String url = UriComponentsBuilder.fromPath("/api/bookings")
+                .queryParam("placeId", placeId)
+                .queryParam("date", date)
+                .toUriString();
 
-        ApiResult<DailyBookingStatusRes> body = result.getBody();
-        assertThat(body).isNotNull();
-        assertThat(body.code()).isEqualTo(200);
-        assertThat(body.status()).isEqualTo(HttpStatus.OK);
+            // when
+            ResponseEntity<ApiResult<DailyBookingStatusRes>> result = template.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {
+                }
+            );
 
-        DailyBookingStatusRes data = body.data();
-        assertThat(data).isNotNull();
-        assertThat(data.placeId()).isEqualTo(placeId);
-        assertThat(data.date()).isEqualTo(date);
-        assertThat(data.timeList()).hasSize(1);
-        assertThat(data.timeList().get(0).time()).isEqualTo("18:00");
-        assertThat(data.timeList().get(0).available()).isTrue();
+            // then
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            ApiResult<DailyBookingStatusRes> body = result.getBody();
+            assertThat(body).isNotNull();
+            assertThat(body.code()).isEqualTo(200);
+            assertThat(body.status()).isEqualTo(HttpStatus.OK);
+
+            DailyBookingStatusRes data = body.data();
+            assertThat(data).isNotNull();
+            assertThat(data.placeId()).isEqualTo(placeId);
+            assertThat(data.date()).isEqualTo(date);
+            assertThat(data.timeList()).hasSize(1);
+            assertThat(data.timeList().get(0).time()).isEqualTo("18:00");
+            assertThat(data.timeList().get(0).available()).isTrue();
+        }
+
+        private static BookingSlot createBookingSlot(long placeId, LocalDate date, LocalTime time) {
+            return new BookingSlot(1L, placeId, 1L, date, time, false, true, true, 1L);
+        }
     }
 
     @DisplayName("사용자는 특정 날짜와 시간에 테이블을 예약할 수 있다")

--- a/nowait-api/src/test/java/com/nowait/booking/application/BookingServiceTest.java
+++ b/nowait-api/src/test/java/com/nowait/booking/application/BookingServiceTest.java
@@ -1,0 +1,95 @@
+package com.nowait.booking.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.nowait.booking.domain.model.BookingSlot;
+import com.nowait.booking.domain.repository.BookingSlotRepository;
+import com.nowait.booking.dto.response.DailyBookingStatusRes;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig(BookingService.class)
+class BookingServiceTest {
+
+    @Autowired
+    BookingService bookingService;
+
+    @MockBean
+    BookingSlotRepository bookingSlotRepository;
+
+    @Nested
+    @DisplayName("예약 현황 조회 테스트")
+    class GetDailyBookingStatusTest {
+
+        long placeId;
+        LocalDate date;
+
+        @BeforeEach
+        void setUp() {
+            placeId = 1L;
+            date = LocalDate.of(2024, 12, 25);
+        }
+
+        @DisplayName("특정 날짜에 예약 가능 시간과 예약 상태를 확인할 수 있다")
+        @Test
+        void getDailyBookingStatus() {
+            // given
+            List<BookingSlot> bookingSlots = List.of(
+                createBookingSlot(LocalTime.of(18, 0), false),
+                createBookingSlot(LocalTime.of(19, 0), true)
+            );
+
+            when(bookingSlotRepository.findAllByPlaceIdAndDate(any(Long.class),
+                any(LocalDate.class))).thenReturn(bookingSlots);
+
+            // when
+            DailyBookingStatusRes response = bookingService.getDailyBookingStatus(placeId, date);
+
+            // then
+            assertThat(response.timeList()).hasSize(2);
+            assertThat(response.timeList().get(0).time()).isEqualTo(LocalTime.of(18, 0));
+            assertThat(response.timeList().get(0).available()).isTrue();
+            assertThat(response.timeList().get(1).time()).isEqualTo(LocalTime.of(19, 0));
+            assertThat(response.timeList().get(1).available()).isFalse();
+        }
+
+        @DisplayName("해당 시간의 모든 테이블이 예약된 경우에만 예약 불가능한 상태가 된다")
+        @Test
+        void getDailyBookingStatus2() {
+            // given
+            List<BookingSlot> bookingSlots = List.of(
+                createBookingSlot(LocalTime.of(18, 0), true),
+                createBookingSlot(LocalTime.of(18, 0), false),
+                createBookingSlot(LocalTime.of(19, 0), true),
+                createBookingSlot(LocalTime.of(19, 0), true)
+            );
+
+            when(bookingSlotRepository.findAllByPlaceIdAndDate(any(Long.class),
+                any(LocalDate.class))).thenReturn(bookingSlots);
+
+            // when
+            DailyBookingStatusRes response = bookingService.getDailyBookingStatus(placeId, date);
+
+            // then
+            assertThat(response.timeList()).hasSize(2);
+            assertThat(response.timeList().get(0).time()).isEqualTo(LocalTime.of(18, 0));
+            assertThat(response.timeList().get(0).available()).isTrue();
+            assertThat(response.timeList().get(1).time()).isEqualTo(LocalTime.of(19, 0));
+            assertThat(response.timeList().get(1).available()).isFalse();
+        }
+
+        private BookingSlot createBookingSlot(LocalTime time, boolean isBooked) {
+            return new BookingSlot(null, placeId, null, date, time, isBooked, false, false, null);
+        }
+    }
+}

--- a/nowait-api/src/test/resources/application.yml
+++ b/nowait-api/src/test/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL;DB_CLOSE_ON_EXIT=FALSE;
+    username: sa
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop


### PR DESCRIPTION
## 🔗 관련 이슈
<!--이슈를 해결하고 닫는다면 Resolves #번호-->
<!--이슈가 해결되지 않았지만 닫는다면 Closes #번호-->
<!--보고된 버그를 해결하고 관련 이슈를 닫는다면 Fixes #번호-->
Resolves #9

## 👩🏻‍💻 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- H2, Spring Data Jpa 의존성 추가
- `Booking`, `BookingSlot` 엔티티 생성
- 예약 현황 조회 기능 구현
- 예약 현황 조회 단위 테스트 작성
- 예약 현황 조회 통합 테스트 수정

### 예약 ERD
![스크린샷 2024-12-03 18 16 02](https://github.com/user-attachments/assets/4dcc9bcc-f711-4a07-8c70-a62ba606f894)

### 예약 슬롯 ERD
![스크린샷 2024-12-03 18 15 12](https://github.com/user-attachments/assets/353bef22-6ca3-4372-8958-d3465365fd20)

## 💬 고민되는 점
- 예약 슬롯에 isBooked 컬럼이 사실 데이터 중복인데, 편의를 위해 반정규화를 했습니다! 정규화를 어디까지 진행해야 하는지 고민이 되네요..
- 예약이 승인 대기 중 / 결제 대기 중일때도 일단 예약된걸로 하는 것이 좋겠죠?
- 엔티티(모델) 간에 의존성이 줄이는 것이 추후 확장에서 도움이 될 것 같아, FK를 두지 않았습니다! 혹시 이 방식에 대해 의견을 들을 수 있을까요?
