### PR TITLE
[Feat] 예약 현황 조회 / 예약 하기 기능 구현

### DIFF
--- a/nowait-api/build.gradle
+++ b/nowait-api/build.gradle
@@ -16,6 +16,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // H2
+    runtimeOnly 'com.h2database:h2'
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/nowait-api/src/main/java/com/nowait/booking/api/BookingApi.java
+++ b/nowait-api/src/main/java/com/nowait/booking/api/BookingApi.java
@@ -1,6 +1,8 @@
 package com.nowait.booking.api;
 
-import com.nowait.booking.dto.TimeSlotDto;
+import static java.util.Objects.isNull;
+
+import com.nowait.booking.application.BookingService;
 import com.nowait.booking.dto.request.BookingReq;
 import com.nowait.booking.dto.response.BookingRes;
 import com.nowait.booking.dto.response.DailyBookingStatusRes;
@@ -11,7 +13,6 @@ import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,6 +29,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class BookingApi {
 
+    private final BookingService bookingService;
+
     /**
      * 가게 예약 현황 조회 API
      *
@@ -40,12 +43,8 @@ public class BookingApi {
         @RequestParam Long placeId,
         @RequestParam(required = false) LocalDate date
     ) {
-        // TODO: 예약 현황 조회 비즈니스 로직 호출
-
-        return ApiResult.ok(
-            new DailyBookingStatusRes(placeId, date,
-                List.of(new TimeSlotDto(LocalTime.of(18, 0), true)))
-        );
+        date = isNull(date) ? LocalDate.now() : date;
+        return ApiResult.ok(bookingService.getDailyBookingStatus(placeId, date));
     }
 
     /**

--- a/nowait-api/src/main/java/com/nowait/booking/api/BookingApi.java
+++ b/nowait-api/src/main/java/com/nowait/booking/api/BookingApi.java
@@ -1,8 +1,7 @@
 package com.nowait.booking.api;
 
-import static java.util.Objects.isNull;
-
 import com.nowait.booking.application.BookingService;
+import com.nowait.booking.dto.TimeSlotDto;
 import com.nowait.booking.dto.request.BookingReq;
 import com.nowait.booking.dto.response.BookingRes;
 import com.nowait.booking.dto.response.DailyBookingStatusRes;
@@ -13,6 +12,7 @@ import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -43,8 +43,12 @@ public class BookingApi {
         @RequestParam Long placeId,
         @RequestParam(required = false) LocalDate date
     ) {
-        date = isNull(date) ? LocalDate.now() : date;
-        return ApiResult.ok(bookingService.getDailyBookingStatus(placeId, date));
+        // TODO: 예약 현황 조회 비즈니스 로직 호출
+
+        return ApiResult.ok(
+            new DailyBookingStatusRes(placeId, date,
+                List.of(new TimeSlotDto(LocalTime.of(18, 0), true)))
+        );
     }
 
     /**

--- a/nowait-api/src/main/java/com/nowait/booking/application/BookingEventPublisher.java
+++ b/nowait-api/src/main/java/com/nowait/booking/application/BookingEventPublisher.java
@@ -1,0 +1,21 @@
+package com.nowait.booking.application;
+
+import com.nowait.booking.domain.model.Booking;
+import com.nowait.common.event.BookedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BookingEventPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Async
+    public void publishBookedEvent(Booking booking, Long placeId) {
+        eventPublisher.publishEvent(
+            new BookedEvent(booking.getId(), placeId, booking.getUserId()));
+    }
+}

--- a/nowait-api/src/main/java/com/nowait/booking/application/BookingService.java
+++ b/nowait-api/src/main/java/com/nowait/booking/application/BookingService.java
@@ -1,0 +1,36 @@
+package com.nowait.booking.application;
+
+import com.nowait.booking.domain.model.BookingSlot;
+import com.nowait.booking.domain.repository.BookingSlotRepository;
+import com.nowait.booking.dto.TimeSlotDto;
+import com.nowait.booking.dto.response.DailyBookingStatusRes;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookingService {
+
+    private final BookingSlotRepository bookingSlotRepository;
+
+    public DailyBookingStatusRes getDailyBookingStatus(Long placeId, LocalDate date) {
+        List<BookingSlot> bookingSlots = bookingSlotRepository.findAllByPlaceIdAndDate(
+            placeId, date);
+
+        List<TimeSlotDto> timeSlots = bookingSlots.stream()
+            .collect(Collectors.groupingBy(BookingSlot::getTime))
+            .entrySet().stream()
+            .map(entry -> new TimeSlotDto(entry.getKey(), isAvailable(entry.getValue())))
+            .toList();
+
+        return new DailyBookingStatusRes(placeId, date, timeSlots);
+    }
+
+    private boolean isAvailable(List<BookingSlot> slots) {
+        // 모든 슬롯이 예약된 경우에만 false 반환
+        return slots.stream().anyMatch(slot -> !slot.isBooked());
+    }
+}

--- a/nowait-api/src/main/java/com/nowait/booking/application/BookingService.java
+++ b/nowait-api/src/main/java/com/nowait/booking/application/BookingService.java
@@ -1,20 +1,33 @@
 package com.nowait.booking.application;
 
+import com.nowait.booking.domain.model.Booking;
 import com.nowait.booking.domain.model.BookingSlot;
+import com.nowait.booking.domain.repository.BookingRepository;
 import com.nowait.booking.domain.repository.BookingSlotRepository;
 import com.nowait.booking.dto.TimeSlotDto;
+import com.nowait.booking.dto.response.BookingRes;
 import com.nowait.booking.dto.response.DailyBookingStatusRes;
+import com.nowait.place.domain.repository.PlaceRepository;
+import com.nowait.user.domain.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class BookingService {
 
     private final BookingSlotRepository bookingSlotRepository;
+    private final BookingRepository bookingRepository;
+    private final UserRepository userRepository;
+    private final PlaceRepository placeRepository;
+    private final BookingEventPublisher bookingEventPublisher;
 
     public DailyBookingStatusRes getDailyBookingStatus(Long placeId, LocalDate date) {
         List<BookingSlot> bookingSlots = bookingSlotRepository.findAllByPlaceIdAndDate(
@@ -29,8 +42,39 @@ public class BookingService {
         return new DailyBookingStatusRes(placeId, date, timeSlots);
     }
 
+    @Transactional
+    public BookingRes book(Long loginId, Long placeId, LocalDate date, LocalTime time,
+        Integer partySize) {
+        validateUserExist(loginId, "존재하지 않는 사용자의 요청입니다.");
+        validatePlaceExist(placeId, "존재하지 않는 식당입니다.");
+
+        BookingSlot slot = findAvailableSlot(placeId, date, time);
+        Booking booking = bookingRepository.save(Booking.of(loginId, partySize, slot));
+
+        bookingEventPublisher.publishBookedEvent(booking, placeId);
+
+        return BookingRes.of(booking, slot);
+    }
+
     private boolean isAvailable(List<BookingSlot> slots) {
         // 모든 슬롯이 예약된 경우에만 false 반환
         return slots.stream().anyMatch(slot -> !slot.isBooked());
+    }
+
+    private void validateUserExist(Long userId, String errorMessage) {
+        if (!userRepository.existsById(userId)) {
+            throw new EntityNotFoundException(errorMessage);
+        }
+    }
+
+    private void validatePlaceExist(Long placeId, String errorMessage) {
+        if (!placeRepository.existsById(placeId)) {
+            throw new EntityNotFoundException(errorMessage);
+        }
+    }
+
+    private BookingSlot findAvailableSlot(Long placeId, LocalDate date, LocalTime time) {
+        return bookingSlotRepository.findFirstByPlaceIdAndDateAndTimeAndIsBookedFalse(placeId, date,
+            time).orElseThrow(() -> new IllegalArgumentException("예약 가능한 테이블이 없습니다."));
     }
 }

--- a/nowait-api/src/main/java/com/nowait/booking/domain/model/Booking.java
+++ b/nowait-api/src/main/java/com/nowait/booking/domain/model/Booking.java
@@ -1,0 +1,38 @@
+package com.nowait.booking.domain.model;
+
+import com.nowait.common.domain.model.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "booking")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Booking extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "booking_slot_id", nullable = false)
+    private Long bookingSlotId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "status", nullable = false, columnDefinition = "varchar(20)")
+    private BookingStatus status;
+}

--- a/nowait-api/src/main/java/com/nowait/booking/domain/model/Booking.java
+++ b/nowait-api/src/main/java/com/nowait/booking/domain/model/Booking.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "booking")
 @Getter
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Booking extends BaseTimeEntity {
 
@@ -26,7 +26,7 @@ public class Booking extends BaseTimeEntity {
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "booking_slot_id", nullable = false)
+    @Column(name = "booking_slot_id", nullable = false, unique = true)
     private Long bookingSlotId;
 
     @Column(name = "user_id", nullable = false)
@@ -35,4 +35,17 @@ public class Booking extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     @Column(name = "status", nullable = false, columnDefinition = "varchar(20)")
     private BookingStatus status;
+
+    @Column(name = "party_size")
+    private Integer partySize;
+
+    public static Booking of(Long userId, Integer partySize, BookingSlot slot) {
+        return new Booking(
+            null,
+            slot.getId(),
+            userId,
+            slot.book(),
+            partySize
+        );
+    }
 }

--- a/nowait-api/src/main/java/com/nowait/booking/domain/model/BookingSlot.java
+++ b/nowait-api/src/main/java/com/nowait/booking/domain/model/BookingSlot.java
@@ -49,4 +49,15 @@ public class BookingSlot extends BaseTimeEntity {
 
     @Column(name = "deposit_policy_id")
     private Long deposit_policy_id;
+
+    public BookingStatus book() {
+        if (isBooked) {
+            throw new IllegalArgumentException("이미 예약된 테이블입니다.");
+        }
+
+        isBooked = true;
+
+        return isDepositRequired() ? BookingStatus.PENDING_PAYMENT
+            : isConfirmRequired() ? BookingStatus.PENDING_CONFIRM : BookingStatus.CONFIRMED;
+    }
 }

--- a/nowait-api/src/main/java/com/nowait/booking/domain/model/BookingSlot.java
+++ b/nowait-api/src/main/java/com/nowait/booking/domain/model/BookingSlot.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "booking_slot")
 @Getter
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BookingSlot extends BaseTimeEntity {
 

--- a/nowait-api/src/main/java/com/nowait/booking/domain/model/BookingSlot.java
+++ b/nowait-api/src/main/java/com/nowait/booking/domain/model/BookingSlot.java
@@ -1,0 +1,52 @@
+package com.nowait.booking.domain.model;
+
+import com.nowait.common.domain.model.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "booking_slot")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BookingSlot extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "place_id", nullable = false)
+    private Long placeId;
+
+    @Column(name = "table_id", nullable = false)
+    private Long tableId;
+
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    @Column(name = "time", nullable = false)
+    private LocalTime time;
+
+    @Column(name = "is_booked")
+    private boolean isBooked;
+
+    @Column(name = "deposit_required")
+    private boolean depositRequired;
+
+    @Column(name = "confirm_required")
+    private boolean confirmRequired;
+
+    @Column(name = "deposit_policy_id")
+    private Long deposit_policy_id;
+}

--- a/nowait-api/src/main/java/com/nowait/booking/domain/model/BookingStatus.java
+++ b/nowait-api/src/main/java/com/nowait/booking/domain/model/BookingStatus.java
@@ -1,0 +1,13 @@
+package com.nowait.booking.domain.model;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum BookingStatus {
+    CONFIRMED("확정됨"),
+    PENDING_CONFIRM("확정 대기 중"),
+    PENDING_PAYMENT("결재 대기 중"),
+    CANCELLED("취소됨");
+
+    private final String description;
+}

--- a/nowait-api/src/main/java/com/nowait/booking/domain/model/BookingStatus.java
+++ b/nowait-api/src/main/java/com/nowait/booking/domain/model/BookingStatus.java
@@ -1,7 +1,9 @@
 package com.nowait.booking.domain.model;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public enum BookingStatus {
     CONFIRMED("확정됨"),

--- a/nowait-api/src/main/java/com/nowait/booking/domain/repository/BookingRepository.java
+++ b/nowait-api/src/main/java/com/nowait/booking/domain/repository/BookingRepository.java
@@ -1,0 +1,8 @@
+package com.nowait.booking.domain.repository;
+
+import com.nowait.booking.domain.model.Booking;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookingRepository extends JpaRepository<Booking, Long> {
+
+}

--- a/nowait-api/src/main/java/com/nowait/booking/domain/repository/BookingSlotRepository.java
+++ b/nowait-api/src/main/java/com/nowait/booking/domain/repository/BookingSlotRepository.java
@@ -1,0 +1,11 @@
+package com.nowait.booking.domain.repository;
+
+import com.nowait.booking.domain.model.BookingSlot;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookingSlotRepository extends JpaRepository<BookingSlot, Long> {
+
+    List<BookingSlot> findAllByPlaceIdAndDate(Long placeId, LocalDate date);
+}

--- a/nowait-api/src/main/java/com/nowait/booking/domain/repository/BookingSlotRepository.java
+++ b/nowait-api/src/main/java/com/nowait/booking/domain/repository/BookingSlotRepository.java
@@ -2,10 +2,15 @@ package com.nowait.booking.domain.repository;
 
 import com.nowait.booking.domain.model.BookingSlot;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookingSlotRepository extends JpaRepository<BookingSlot, Long> {
 
     List<BookingSlot> findAllByPlaceIdAndDate(Long placeId, LocalDate date);
+
+    Optional<BookingSlot> findFirstByPlaceIdAndDateAndTimeAndIsBookedFalse(Long placeId,
+        LocalDate date, LocalTime time);
 }

--- a/nowait-api/src/main/java/com/nowait/booking/dto/response/BookingRes.java
+++ b/nowait-api/src/main/java/com/nowait/booking/dto/response/BookingRes.java
@@ -1,5 +1,8 @@
 package com.nowait.booking.dto.response;
 
+import com.nowait.booking.domain.model.Booking;
+import com.nowait.booking.domain.model.BookingSlot;
+
 public record BookingRes(
     Long bookingId,
     String bookingStatus,
@@ -7,4 +10,12 @@ public record BookingRes(
     boolean confirmRequired
 ) {
 
+    public static BookingRes of(Booking booking, BookingSlot slot) {
+        return new BookingRes(
+            booking.getId(),
+            booking.getStatus().getDescription(),
+            slot.isDepositRequired(),
+            slot.isConfirmRequired()
+        );
+    }
 }

--- a/nowait-api/src/main/java/com/nowait/common/config/JpaConfig.java
+++ b/nowait-api/src/main/java/com/nowait/common/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.nowait.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/nowait-api/src/main/java/com/nowait/common/domain/model/BaseTimeEntity.java
+++ b/nowait-api/src/main/java/com/nowait/common/domain/model/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.nowait.common.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/nowait-api/src/main/java/com/nowait/common/event/BookedEvent.java
+++ b/nowait-api/src/main/java/com/nowait/common/event/BookedEvent.java
@@ -1,0 +1,9 @@
+package com.nowait.common.event;
+
+public record BookedEvent(
+    Long bookingId,
+    Long placeId,
+    Long userId
+) {
+
+}

--- a/nowait-api/src/main/java/com/nowait/place/domain/model/Place.java
+++ b/nowait-api/src/main/java/com/nowait/place/domain/model/Place.java
@@ -1,0 +1,46 @@
+package com.nowait.place.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "place")
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Place {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description")
+    private String description;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "type", nullable = false, columnDefinition = "varchar(30)")
+    private PlaceType type;
+
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    @Column(name = "old_address")
+    private String oldAddress;
+
+    @Column(name = "road_address")
+    private String roadAddress;
+}

--- a/nowait-api/src/main/java/com/nowait/place/domain/model/PlaceType.java
+++ b/nowait-api/src/main/java/com/nowait/place/domain/model/PlaceType.java
@@ -1,0 +1,13 @@
+package com.nowait.place.domain.model;
+
+public enum PlaceType {
+    KOREAN,
+    JAPANESE,
+    CHINESE,
+    AMERICAN,
+    RESTAURANT,
+    CAFE,
+    BAKERY,
+    BAR,
+    PUB
+}

--- a/nowait-api/src/main/java/com/nowait/place/domain/repository/PlaceRepository.java
+++ b/nowait-api/src/main/java/com/nowait/place/domain/repository/PlaceRepository.java
@@ -1,0 +1,8 @@
+package com.nowait.place.domain.repository;
+
+import com.nowait.place.domain.model.Place;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+
+}

--- a/nowait-api/src/main/java/com/nowait/user/domain/model/User.java
+++ b/nowait-api/src/main/java/com/nowait/user/domain/model/User.java
@@ -1,0 +1,28 @@
+package com.nowait.user.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "nickname", nullable = false)
+    private String nickname;
+}

--- a/nowait-api/src/main/java/com/nowait/user/domain/repository/UserRepository.java
+++ b/nowait-api/src/main/java/com/nowait/user/domain/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.nowait.user.domain.repository;
+
+import com.nowait.user.domain.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/nowait-api/src/main/resources/application-local.yml
+++ b/nowait-api/src/main/resources/application-local.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:nowait;MODE=MySQL;
+    username: sa
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true

--- a/nowait-api/src/test/java/com/nowait/booking/api/BookingApiIntegrationTest.java
+++ b/nowait-api/src/test/java/com/nowait/booking/api/BookingApiIntegrationTest.java
@@ -2,7 +2,6 @@ package com.nowait.booking.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.nowait.booking.domain.model.BookingSlot;
 import com.nowait.booking.domain.repository.BookingSlotRepository;
 import com.nowait.booking.dto.request.BookingReq;
 import com.nowait.booking.dto.response.BookingRes;
@@ -55,9 +54,6 @@ class BookingApiIntegrationTest {
             long placeId = 1L;
             LocalDate date = LocalDate.of(2024, 12, 25);
 
-            BookingSlot bookingSlot = createBookingSlot(placeId, date, LocalTime.of(18, 0));
-            bookingSlotRepository.save(bookingSlot);
-
             String url = UriComponentsBuilder.fromPath("/api/bookings")
                 .queryParam("placeId", placeId)
                 .queryParam("date", date)
@@ -87,10 +83,6 @@ class BookingApiIntegrationTest {
             assertThat(data.timeList()).hasSize(1);
             assertThat(data.timeList().get(0).time()).isEqualTo("18:00");
             assertThat(data.timeList().get(0).available()).isTrue();
-        }
-
-        private static BookingSlot createBookingSlot(long placeId, LocalDate date, LocalTime time) {
-            return new BookingSlot(1L, placeId, 1L, date, time, false, true, true, 1L);
         }
     }
 

--- a/nowait-api/src/test/java/com/nowait/booking/api/BookingApiIntegrationTest.java
+++ b/nowait-api/src/test/java/com/nowait/booking/api/BookingApiIntegrationTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -29,7 +28,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc
 class BookingApiIntegrationTest {
 
     @Autowired

--- a/nowait-api/src/test/java/com/nowait/booking/api/BookingApiIntegrationTest.java
+++ b/nowait-api/src/test/java/com/nowait/booking/api/BookingApiIntegrationTest.java
@@ -2,6 +2,8 @@ package com.nowait.booking.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.nowait.booking.domain.model.BookingSlot;
+import com.nowait.booking.domain.repository.BookingSlotRepository;
 import com.nowait.booking.dto.request.BookingReq;
 import com.nowait.booking.dto.response.BookingRes;
 import com.nowait.booking.dto.response.DailyBookingStatusRes;
@@ -12,6 +14,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -30,8 +33,12 @@ import org.springframework.web.util.UriComponentsBuilder;
 class BookingApiIntegrationTest {
 
     @Autowired
-    private TestRestTemplate template;
-    private String authorization;
+    TestRestTemplate template;
+
+    @Autowired
+    BookingSlotRepository bookingSlotRepository;
+
+    String authorization;
 
     @BeforeEach
     void setUp() {
@@ -39,42 +46,54 @@ class BookingApiIntegrationTest {
         authorization = "Bearer " + accessToken;
     }
 
-    @DisplayName("사용자는 특정 날짜에 가게의 예약 가능 시간을 확인할 수 있다")
-    @Test
-    void getDailyBookingStatus() {
-        // given
-        long placeId = 1L;
-        LocalDate date = LocalDate.of(2024, 12, 25);
+    @Nested
+    @DisplayName("예약 현황 조회 테스트")
+    class DailyBookingStatusTest {
 
-        String url = UriComponentsBuilder.fromPath("/api/bookings")
-            .queryParam("placeId", placeId)
-            .queryParam("date", date)
-            .toUriString();
+        @DisplayName("사용자는 특정 날짜에 가게의 예약 가능 시간을 확인할 수 있다")
+        @Test
+        void getDailyBookingStatus() {
+            // given
+            long placeId = 1L;
+            LocalDate date = LocalDate.of(2024, 12, 25);
 
-        // when
-        ResponseEntity<ApiResult<DailyBookingStatusRes>> result = template.exchange(
-            url,
-            HttpMethod.GET,
-            null,
-            new ParameterizedTypeReference<>() {
-            }
-        );
+            BookingSlot bookingSlot = createBookingSlot(placeId, date, LocalTime.of(18, 0));
+            bookingSlotRepository.save(bookingSlot);
 
-        // then
-        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+            String url = UriComponentsBuilder.fromPath("/api/bookings")
+                .queryParam("placeId", placeId)
+                .queryParam("date", date)
+                .toUriString();
 
-        ApiResult<DailyBookingStatusRes> body = result.getBody();
-        assertThat(body).isNotNull();
-        assertThat(body.code()).isEqualTo(200);
-        assertThat(body.status()).isEqualTo(HttpStatus.OK);
+            // when
+            ResponseEntity<ApiResult<DailyBookingStatusRes>> result = template.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {
+                }
+            );
 
-        DailyBookingStatusRes data = body.data();
-        assertThat(data).isNotNull();
-        assertThat(data.placeId()).isEqualTo(placeId);
-        assertThat(data.date()).isEqualTo(date);
-        assertThat(data.timeList()).hasSize(1);
-        assertThat(data.timeList().get(0).time()).isEqualTo("18:00");
-        assertThat(data.timeList().get(0).available()).isTrue();
+            // then
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            ApiResult<DailyBookingStatusRes> body = result.getBody();
+            assertThat(body).isNotNull();
+            assertThat(body.code()).isEqualTo(200);
+            assertThat(body.status()).isEqualTo(HttpStatus.OK);
+
+            DailyBookingStatusRes data = body.data();
+            assertThat(data).isNotNull();
+            assertThat(data.placeId()).isEqualTo(placeId);
+            assertThat(data.date()).isEqualTo(date);
+            assertThat(data.timeList()).hasSize(1);
+            assertThat(data.timeList().get(0).time()).isEqualTo("18:00");
+            assertThat(data.timeList().get(0).available()).isTrue();
+        }
+
+        private static BookingSlot createBookingSlot(long placeId, LocalDate date, LocalTime time) {
+            return new BookingSlot(1L, placeId, 1L, date, time, false, true, true, 1L);
+        }
     }
 
     @DisplayName("사용자는 특정 날짜와 시간에 테이블을 예약할 수 있다")

--- a/nowait-api/src/test/java/com/nowait/booking/application/BookingServiceTest.java
+++ b/nowait-api/src/test/java/com/nowait/booking/application/BookingServiceTest.java
@@ -1,31 +1,54 @@
 package com.nowait.booking.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.nowait.booking.domain.model.Booking;
 import com.nowait.booking.domain.model.BookingSlot;
+import com.nowait.booking.domain.model.BookingStatus;
+import com.nowait.booking.domain.repository.BookingRepository;
 import com.nowait.booking.domain.repository.BookingSlotRepository;
 import com.nowait.booking.dto.response.DailyBookingStatusRes;
+import com.nowait.place.domain.repository.PlaceRepository;
+import com.nowait.user.domain.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@SpringJUnitConfig(BookingService.class)
+@ExtendWith(MockitoExtension.class)
 class BookingServiceTest {
 
-    @Autowired
+    @InjectMocks
     BookingService bookingService;
 
-    @MockBean
+    @Mock
     BookingSlotRepository bookingSlotRepository;
+
+    @Mock
+    BookingRepository bookingRepository;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    PlaceRepository placeRepository;
+
+    @Mock
+    BookingEventPublisher bookingEventPublisher;
 
     @Nested
     @DisplayName("예약 현황 조회 테스트")
@@ -90,6 +113,108 @@ class BookingServiceTest {
 
         private BookingSlot createBookingSlot(LocalTime time, boolean isBooked) {
             return new BookingSlot(null, placeId, null, date, time, isBooked, false, false, null);
+        }
+    }
+
+    @Nested
+    @DisplayName("예약 테스트")
+    class BookingTest {
+
+        @Mock
+        BookingSlot slot;
+        @Mock
+        Booking booking;
+        Long loginId;
+        Long placeId;
+        LocalDate date;
+        LocalTime time;
+        int partySize;
+
+        @BeforeEach
+        void setUp() {
+            loginId = 1L;
+            placeId = 1L;
+            date = LocalDate.of(2024, 12, 25);
+            time = LocalTime.of(18, 0);
+            partySize = 2;
+        }
+
+        @DisplayName("예약 가능한 날짜, 시간에 예약을 할 수 있다.")
+        @Test
+        void book() {
+            // given
+            when(userRepository.existsById(loginId)).thenReturn(true);
+            when(placeRepository.existsById(placeId)).thenReturn(true);
+            when(bookingSlotRepository.findFirstByPlaceIdAndDateAndTimeAndIsBookedFalse(
+                placeId, date, time)).thenReturn(Optional.of(slot));
+            when(bookingRepository.save(any(Booking.class))).thenReturn(booking);
+            when(slot.book()).thenReturn(BookingStatus.CONFIRMED);
+            when(booking.getStatus()).thenReturn(BookingStatus.CONFIRMED);
+
+            // when
+            bookingService.book(loginId, placeId, date, time, partySize);
+
+            // then
+            verify(userRepository).existsById(loginId);
+            verify(placeRepository).existsById(placeId);
+            verify(bookingSlotRepository).findFirstByPlaceIdAndDateAndTimeAndIsBookedFalse(
+                placeId, date, time);
+            verify(bookingRepository).save(any(Booking.class));
+            verify(bookingEventPublisher).publishBookedEvent(booking, placeId);
+        }
+
+        @DisplayName("해당 시간대의 모든 테이블이 이미 예약된 경우에는 예약을 할 수 없다")
+        @Test
+        void alreadyFullyBooked() {
+            // given
+            when(userRepository.existsById(loginId)).thenReturn(true);
+            when(placeRepository.existsById(placeId)).thenReturn(true);
+            when(bookingSlotRepository.findFirstByPlaceIdAndDateAndTimeAndIsBookedFalse(
+                placeId, date, time)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> bookingService.book(loginId, placeId, date, time, partySize))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("예약 가능한 테이블이 없습니다.");
+
+            verify(userRepository).existsById(loginId);
+            verify(placeRepository).existsById(placeId);
+            verify(bookingSlotRepository).findFirstByPlaceIdAndDateAndTimeAndIsBookedFalse(
+                placeId, date, time);
+            verifyNoInteractions(bookingRepository, bookingEventPublisher);
+        }
+
+        @DisplayName("서비스 가입자만 예약을 할 수 있다.")
+        @Test
+        void bookByNonExistUser() {
+            // given
+            when(userRepository.existsById(loginId)).thenReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> bookingService.book(loginId, placeId, date, time, partySize))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("존재하지 않는 사용자의 요청입니다.");
+
+            verify(userRepository).existsById(loginId);
+            verifyNoInteractions(placeRepository, bookingSlotRepository, bookingRepository,
+                bookingEventPublisher);
+        }
+
+        @DisplayName("존재하지 않는 식당에는 예약을 할 수 없다.")
+        @Test
+        void bookWithNonExistPlace() {
+            // given
+            when(userRepository.existsById(loginId)).thenReturn(true);
+            when(placeRepository.existsById(placeId)).thenReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> bookingService.book(loginId, placeId, date, time, partySize))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("존재하지 않는 식당입니다.");
+
+            verify(userRepository).existsById(loginId);
+            verify(placeRepository).existsById(placeId);
+            verifyNoInteractions(bookingSlotRepository, bookingRepository, bookingEventPublisher);
         }
     }
 }

--- a/nowait-api/src/test/java/com/nowait/booking/application/BookingServiceTest.java
+++ b/nowait-api/src/test/java/com/nowait/booking/application/BookingServiceTest.java
@@ -1,0 +1,95 @@
+package com.nowait.booking.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.nowait.booking.domain.model.BookingSlot;
+import com.nowait.booking.domain.repository.BookingSlotRepository;
+import com.nowait.booking.dto.response.DailyBookingStatusRes;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig(BookingService.class)
+class BookingServiceTest {
+
+    @Autowired
+    BookingService bookingService;
+
+    @MockBean
+    BookingSlotRepository bookingSlotRepository;
+
+    @Nested
+    @DisplayName("예약 현황 조회 테스트")
+    class GetDailyBookingStatusTest {
+
+        long placeId;
+        LocalDate date;
+
+        @BeforeEach
+        void setUp() {
+            placeId = 1L;
+            date = LocalDate.of(2024, 12, 25);
+        }
+
+        @DisplayName("특정 날짜에 예약 가능 시간과 예약 상태를 확인할 수 있다")
+        @Test
+        void getDailyBookingStatus() {
+            // given
+            List<BookingSlot> bookingSlots = List.of(
+                createBookingSlot(LocalTime.of(18, 0), false),
+                createBookingSlot(LocalTime.of(19, 0), true)
+            );
+
+            when(bookingSlotRepository.findAllByPlaceIdAndDate(any(Long.class),
+                any(LocalDate.class))).thenReturn(bookingSlots);
+
+            // when
+            DailyBookingStatusRes response = bookingService.getDailyBookingStatus(placeId, date);
+
+            // then
+            assertThat(response.timeList()).hasSize(2);
+            assertThat(response.timeList().get(0).time()).isEqualTo(LocalTime.of(18, 0));
+            assertThat(response.timeList().get(0).available()).isTrue();
+            assertThat(response.timeList().get(1).time()).isEqualTo(LocalTime.of(19, 0));
+            assertThat(response.timeList().get(1).available()).isFalse();
+        }
+
+        @DisplayName("해당 시간의 모든 테이블이 예약된 경우에만 예약 불가능한 상태가 된다")
+        @Test
+        void getDailyBookingStatus2() {
+            // given
+            List<BookingSlot> bookingSlots = List.of(
+                createBookingSlot(LocalTime.of(18, 0), true),
+                createBookingSlot(LocalTime.of(18, 0), false),
+                createBookingSlot(LocalTime.of(19, 0), true),
+                createBookingSlot(LocalTime.of(19, 0), true)
+            );
+
+            when(bookingSlotRepository.findAllByPlaceIdAndDate(any(Long.class),
+                any(LocalDate.class))).thenReturn(bookingSlots);
+
+            // when
+            DailyBookingStatusRes response = bookingService.getDailyBookingStatus(placeId, date);
+
+            // then
+            assertThat(response.timeList()).hasSize(2);
+            assertThat(response.timeList().get(0).time()).isEqualTo(LocalTime.of(18, 0));
+            assertThat(response.timeList().get(0).available()).isTrue();
+            assertThat(response.timeList().get(1).time()).isEqualTo(LocalTime.of(19, 0));
+            assertThat(response.timeList().get(1).available()).isFalse();
+        }
+
+        private BookingSlot createBookingSlot(LocalTime time, boolean isBooked) {
+            return new BookingSlot(null, placeId, null, date, time, isBooked, false, false, null);
+        }
+    }
+}

--- a/nowait-api/src/test/java/com/nowait/booking/application/BookingServiceTest.java
+++ b/nowait-api/src/test/java/com/nowait/booking/application/BookingServiceTest.java
@@ -57,6 +57,13 @@ class BookingServiceTest {
         long placeId;
         LocalDate date;
 
+        @Mock
+        BookingSlot slotAt18;
+        @Mock
+        BookingSlot unavailableSlotAt18;
+        @Mock
+        BookingSlot unavailableSlotAt19;
+
         @BeforeEach
         void setUp() {
             placeId = 1L;
@@ -67,13 +74,16 @@ class BookingServiceTest {
         @Test
         void getDailyBookingStatus() {
             // given
-            List<BookingSlot> bookingSlots = List.of(
-                createBookingSlot(LocalTime.of(18, 0), false),
-                createBookingSlot(LocalTime.of(19, 0), true)
-            );
+            List<BookingSlot> bookingSlots = List.of(slotAt18, unavailableSlotAt19);
 
             when(bookingSlotRepository.findAllByPlaceIdAndDate(any(Long.class),
                 any(LocalDate.class))).thenReturn(bookingSlots);
+
+            when(slotAt18.getTime()).thenReturn(LocalTime.of(18, 0));
+            when(slotAt18.isBooked()).thenReturn(false);
+
+            when(unavailableSlotAt19.getTime()).thenReturn(LocalTime.of(19, 0));
+            when(unavailableSlotAt19.isBooked()).thenReturn(true);
 
             // when
             DailyBookingStatusRes response = bookingService.getDailyBookingStatus(placeId, date);
@@ -91,14 +101,19 @@ class BookingServiceTest {
         void getDailyBookingStatus2() {
             // given
             List<BookingSlot> bookingSlots = List.of(
-                createBookingSlot(LocalTime.of(18, 0), true),
-                createBookingSlot(LocalTime.of(18, 0), false),
-                createBookingSlot(LocalTime.of(19, 0), true),
-                createBookingSlot(LocalTime.of(19, 0), true)
-            );
+                unavailableSlotAt18, slotAt18, unavailableSlotAt19, unavailableSlotAt19);
 
             when(bookingSlotRepository.findAllByPlaceIdAndDate(any(Long.class),
                 any(LocalDate.class))).thenReturn(bookingSlots);
+
+            when(slotAt18.getTime()).thenReturn(LocalTime.of(18, 0));
+            when(slotAt18.isBooked()).thenReturn(false);
+
+            when(unavailableSlotAt18.getTime()).thenReturn(LocalTime.of(18, 0));
+            when(unavailableSlotAt18.isBooked()).thenReturn(true);
+
+            when(unavailableSlotAt19.getTime()).thenReturn(LocalTime.of(19, 0));
+            when(unavailableSlotAt19.isBooked()).thenReturn(true);
 
             // when
             DailyBookingStatusRes response = bookingService.getDailyBookingStatus(placeId, date);
@@ -109,10 +124,6 @@ class BookingServiceTest {
             assertThat(response.timeList().get(0).available()).isTrue();
             assertThat(response.timeList().get(1).time()).isEqualTo(LocalTime.of(19, 0));
             assertThat(response.timeList().get(1).available()).isFalse();
-        }
-
-        private BookingSlot createBookingSlot(LocalTime time, boolean isBooked) {
-            return new BookingSlot(null, placeId, null, date, time, isBooked, false, false, null);
         }
     }
 

--- a/nowait-api/src/test/resources/application.yml
+++ b/nowait-api/src/test/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL;DB_CLOSE_ON_EXIT=FALSE;
+    username: sa
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop


### PR DESCRIPTION
## 🔗 관련 이슈
<!--이슈를 해결하고 닫는다면 Resolves #번호-->
<!--이슈가 해결되지 않았지만 닫는다면 Closes #번호-->
<!--보고된 버그를 해결하고 관련 이슈를 닫는다면 Fixes #번호-->
#10 #11 

## 👩🏻‍💻 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- H2, Spring Data Jpa 의존성 추가
- `Booking`, `BookingSlot`, `Place`, `User` 엔티티 생성
- 예약 현황 조회 기능 구현 및 단위 테스트 작성
- 예약 하기 기능 구현 및 단위 테스트 작성

## 💬 PR 포인트 & 궁금한 점
- 기능을 구현한 뒤 통합 테스트를 연결하려고 했는데, 사용자 생성 / 가게 등록 등이 되어야 예약 현황 조회, 예약 하기가 가능할 것 같더라구요! **보통 통합 테스트에서 given 절에 데이터를 다 준비해 두나요?(ex. 유저 생성, 가게 생성) 아니면 모킹을 해야 할까요?** 통합 테스트라 모킹을 하면 안될 것 같긴한데.. 그럼 회원 가입 / 가게 등록 로직을 구현하고 통합 테스트와 연결해야 할까요?
- 현재는 예약이 결제 대기 중 or 확정 대기 중이더라도, 일단 해당 예약 슬롯에 예약이 있으면 다른 사람이 예약을 하지 못하도록 되어 있는데요! 만약 결제가 너무 오랫동안되지 않았거나, 확정 대기가 길어지면 따로 배치를 통해 삭제하도록 할지 고민 중인데, 이 방법으로 해도 괜찮을까요?
- 각 레이어 (controller, service, domain) 별로 입력값을 검증하는 것을 좋을지.. 앞에 레이어를 신뢰하고 컨트롤러에서만 검증하도록 할지 고민이 됩니다.! 레이어별로 검증하는 것이 베스트지만, 중복이 되는 것 같은 느낌도 들어서요 😢
- 나머지는 댓글로 달아 놓겠습니다!
