### PR TITLE
[Refactor] 비즈니스 로직 처리을 비동기로 변경

### DIFF
--- a/nowait-api/src/main/java/com/nowait/config/ThreadPoolConfig.java
+++ b/nowait-api/src/main/java/com/nowait/config/ThreadPoolConfig.java
@@ -1,0 +1,23 @@
+package com.nowait.config;
+
+import jakarta.annotation.PreDestroy;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ThreadPoolConfig {
+
+    @Bean
+    public ExecutorService cachedThreadPool() {
+        return Executors.newCachedThreadPool();
+    }
+
+    @PreDestroy
+    public void shutdownThreadPool() {
+        if (cachedThreadPool() != null && !cachedThreadPool().isShutdown()) {
+            cachedThreadPool().shutdown();
+        }
+    }
+}

--- a/nowait-api/src/main/java/com/nowait/config/ThreadPoolConfig.java
+++ b/nowait-api/src/main/java/com/nowait/config/ThreadPoolConfig.java
@@ -3,6 +3,7 @@ package com.nowait.config;
 import jakarta.annotation.PreDestroy;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,14 +11,21 @@ import org.springframework.context.annotation.Configuration;
 public class ThreadPoolConfig {
 
     @Bean
-    public ExecutorService cachedThreadPool() {
+    public ExecutorService threadPool() {
         return Executors.newCachedThreadPool();
     }
 
     @PreDestroy
-    public void shutdownThreadPool() {
-        if (cachedThreadPool() != null && !cachedThreadPool().isShutdown()) {
-            cachedThreadPool().shutdown();
+    public void gracefulShutdown() {
+        if (threadPool() != null && !threadPool().isShutdown()) {
+            threadPool().shutdown();
+            try {
+                if (!threadPool().awaitTermination(30, TimeUnit.SECONDS)) {
+                    threadPool().shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                threadPool().shutdownNow();
+            }
         }
     }
 }

--- a/nowait-api/src/main/java/com/nowait/controller/api/BookingApi.java
+++ b/nowait-api/src/main/java/com/nowait/controller/api/BookingApi.java
@@ -42,14 +42,14 @@ public class BookingApi {
      * @return 해당 날짜의 시간별 예약 현황
      */
     @GetMapping
-    public ApiResult<DailyBookingStatusRes> getDailyBookingStatus(
+    public CompletableFuture<ApiResult<DailyBookingStatusRes>> getDailyBookingStatus(
         @RequestParam Long placeId,
         @RequestParam(required = false) LocalDate date
     ) {
-        date = isNull(date) ? LocalDate.now() : date;
-        DailyBookingStatusRes data = bookingService.getDailyBookingStatus(placeId, date);
-
-        return ApiResult.ok(data);
+        LocalDate targetDate = isNull(date) ? LocalDate.now() : date;
+        return CompletableFuture.supplyAsync(
+                () -> bookingService.getDailyBookingStatus(placeId, targetDate), executorService)
+            .thenApply(ApiResult::ok);
     }
 
     /**


### PR DESCRIPTION
## 🔗 관련 이슈
<!--이슈를 해결하고 닫는다면 Resolves #번호-->
<!--이슈가 해결되지 않았지만 닫는다면 Closes #번호-->
<!--보고된 버그를 해결하고 관련 이슈를 닫는다면 Fixes #번호-->
Resolves #22 

## 👩🏻‍💻 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- ThreadPoolConfig 생성 후 `Executors.newCachedThreadPool()` 빈으로 등록
  - `CompletableFuture`가 기본적으로 `ForkJoinPool.commonPool`을 사용합니다! 해당 풀은 스레드 수가 CPU 수로 고정되어 있어 저희 목적과 맞지 않는다고 판단하여, 스레드 수를 동적으로 관리하는 `Executors.newCachedThreadPool()`를 사용했습니다.
  - 그리고 여러 컨트롤러에서 같은 Pool을 사용하도록 하기 위해 빈으로 등록 후 애플리케이션 종료 시 Pool을 종료하는 작업을 추가했습니다.
- 예약 비즈니스 로직을 비동기로 변경했습니다. 실제로 다른 스레드에서 실행되는 것을 로그로 확인했습니다!

![image](https://github.com/user-attachments/assets/755720e2-91c1-4d2a-ac15-e289a32ad963)


## 💬 궁금한 점 / 코멘트
- 일단 예약 기능만 비동기로 변경을 했습니다! 모든 API를 비동기로 변경할까 하는데 괜찮을까요?
- 이번 PR과 관련해서 블로그 글을 작성해 보았습니다! 
  [CompletableFuture를 이용해 비즈니스 로직을 비동기로 처리하여 대규모 트래픽에 대응하기](https://velog.io/@uijin/CompletableFuture%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%B4-%EB%B9%84%EC%A6%88%EB%8B%88%EC%8A%A4-%EB%A1%9C%EC%A7%81%EC%9D%84-%EB%B9%84%EB%8F%99%EA%B8%B0%EB%A1%9C-%EC%B2%98%EB%A6%AC%ED%95%98%EC%97%AC-%EB%8C%80%EA%B7%9C%EB%AA%A8-%ED%8A%B8%EB%9E%98%ED%94%BD%EC%97%90-%EB%8C%80%EC%9D%91%ED%95%98%EA%B8%B0) 
